### PR TITLE
Making pasted compile logs less painful to the eyes

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,3 +2,12 @@
 Also have a look at the [Wiki](https://github.com/spacehuhn/esp8266_deauther/wiki).  
 Please put error messages and code ```inside these 3 quotes/grave accents```
 (Delete this text when you've read it)
+
+
+<details>
+  <summary> Compile log (...)</summary>
+
+  <!-- PASTE YOUR COMPILE LOGS HERE -->
+
+</details>
+<br><br><br>


### PR DESCRIPTION
Because esp8266 compile logs are huge, it's nice to be able to fold/unfold them,

See [this issue comment](https://github.com/spacehuhn/esp8266_deauther/issues/668#issuecomment-446925708) as an example